### PR TITLE
Initalize plugin info before we check if other plugins have been started

### DIFF
--- a/DFAssist/DFAssistPlugin.cs
+++ b/DFAssist/DFAssistPlugin.cs
@@ -55,6 +55,8 @@ namespace DFAssist
             if (!EnsureActMainFormIsLoaded())
                 return;
 
+            InitializePluginVariables(mainControl);
+
             if (!FFXIVPluginHelper.Instance.Check(_pluginData, ffPluginIsEnabled =>
              {
                  if (ffPluginIsEnabled)
@@ -67,7 +69,7 @@ namespace DFAssist
             _pluginInitializing = true;
             ActGlobals.oFormActMain.Shown -= ActMainFormOnShown;
 
-            InitializePluginVariables(mainControl);
+            
 
             _localizationRepository = Locator.Current.GetService<ILocalizationRepository>();
             _dataRepository = Locator.Current.GetService<IDataRepository>();

--- a/DFAssist/Helpers/FFXIVPluginHelper.cs
+++ b/DFAssist/Helpers/FFXIVPluginHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Windows;
 using Advanced_Combat_Tracker;
 
 namespace DFAssist.Helpers
@@ -28,15 +29,15 @@ namespace DFAssist.Helpers
             // than this plugin cannot start
             if (_ffxivPluginData == null)
             {
+                MessageBox.Show($"{ffxivActPluginDll} must be installed BEFORE DFAssist!");
                 dfAssistPluginData.cbEnabled.Checked = false;
-                dfAssistPluginData.lblPluginStatus.Text = $"{ffxivActPluginDll} must be installed BEFORE DFAssist!";
                 return false;
             }
 
             if (!_ffxivPluginData.cbEnabled.Checked)
             {
+                MessageBox.Show($"{ffxivActPluginDll} must be enabled");
                 dfAssistPluginData.cbEnabled.Checked = false;
-                dfAssistPluginData.lblPluginStatus.Text = $"{ffxivActPluginDll} must be enabled";
                 return false;
             }
 


### PR DESCRIPTION
Make it more obvious that the act plugin needs to be loaded first by displaying a popup message